### PR TITLE
Add better error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "webpack": "^3.10.0"
   },
   "scripts": {
+    "develop": "babel src --out-dir dist --watch",
     "build": "babel src --out-dir dist",
     "prepublish": "npm run build",
     "test": "jest"


### PR DESCRIPTION
Previously, the loader would assume the compilation succeeded. When an
error occured, it would fail when trying to parse the compiler's output
and find that no files were emitted.

This PR fixes this issue by making the loader emit errors so the
developer could see the issues and correct them.