### PR TITLE
ES6 style imports for bindgen Webpack 4

### DIFF
--- a/examples/advanced-wasm-bindgen-webpack4-native-wasm/src/index.js
+++ b/examples/advanced-wasm-bindgen-webpack4-native-wasm/src/index.js
@@ -1,3 +1,5 @@
+import { wasmBooted, hello_world } from '../../advanced-wasm-bindgen/src/lib.rs';
+
 const firstNameInput = document.getElementById('firstName');
 const lastNameInput = document.getElementById('lastName');
 const outputElement = document.getElementById('output');
@@ -5,7 +7,7 @@ const outputElement = document.getElementById('output');
 const update = () => {
   const firstName = firstNameInput.value;
   const lastName = lastNameInput.value;
-  import('../../advanced-wasm-bindgen/src/lib.rs').then(({hello_world}) => outputElement.textContent = hello_world(firstName, lastName));
+  wasmBooted.then(() => outputElement.textContent = hello_world(firstName, lastName));
 };
 
 firstNameInput.addEventListener('input', update);

--- a/examples/advanced-wasm-bindgen-webpack4-native-wasm/webpack.config.js
+++ b/examples/advanced-wasm-bindgen-webpack4-native-wasm/webpack.config.js
@@ -31,12 +31,6 @@ module.exports = {
             test: /\.rs$/,
             use: [
               {
-                loader: 'babel-loader',
-                options: {
-                  compact: true,
-                }
-              },
-              {
                 loader: 'rust-native-wasm-loader',
                 options: {
                   release: true,


### PR DESCRIPTION
I made a small tweak to the loader so bindgen-Rust can be imported using a standard ES6 style import instead of a dynamic import (the dynamic import is now generated by the loader). This is a bit more convenient and keeps the same style of imports everywhere. Similar to when using `wasm2es6js`, a promise, `wasmBooted` is exported. Once the promise resolves, the imported names are available for use.

This currently doesn't have a test as the project pins webpack@3. Webpack 4 would also need to be included to test, which is tricky/not particularly possible with npm. I could probably mock some of this out and write a sanity test, at the least. I'm open to anything here.