### PR TITLE
Update readme on setting the default toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ cargo init add
 cd add
 ```
 
+If nightly is not your system default toolchain, create a file named `rust-toolchain` containing
+the toolchain name you want to associate with the project:
+
+```
+echo nightly > rust-toolchain
+```
+
 We can add the Rust code that should be available in the WebAssembly module to `src/lib.rs`.  All
 functions that should be reachable from WebAssembly should be marked with `#[no_mangle]`:
 


### PR DESCRIPTION
A small thing, but as somebody completely new to Rust, I had to dig quite deep to figure out why my build failed (especially since the latest release of rust-native-wasm-loader swallows the errors). I presume anyone who uses this loader wants to default to the nightly.